### PR TITLE
[codex] Vite TypeScript scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.DS_Store
+*.local
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# game_tetris_like
+# Falling Blocks
+
+PCブラウザ向けの落ち物パズルゲームです。GitHub Pages で公開できる静的Webアプリとして開発します。
+
+現時点では Vite + TypeScript の初期構成のみです。ゲームロジック、Docker、GitHub Pages デプロイ、操作説明は後続Issueで実装します。
+
+## 初期開発コマンド
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run test
+npm run preview
+```
+
+## 方針
+
+- 外部APIは使いません
+- サーバーサイド処理は使いません
+- PCブラウザの Chrome / Edge を優先します
+- 任天堂・公式テトリスの画像、音源、ロゴ、商標表現は使いません

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A browser-based falling block puzzle game for PC browsers."
+    />
+    <title>Falling Blocks</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "falling-blocks",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "vite": "^6.3.0"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,34 @@
+import './styles/app.css';
+
+const app = document.querySelector<HTMLDivElement>('#app');
+
+if (!app) {
+  throw new Error('App root element was not found.');
+}
+
+app.innerHTML = `
+  <main class="app-shell" aria-labelledby="app-title">
+    <section class="title-screen">
+      <p class="eyebrow">PC Browser Puzzle</p>
+      <h1 id="app-title">Falling Blocks</h1>
+      <p class="summary">
+        A static web app foundation for a keyboard and Gamepad API controlled
+        falling block puzzle game.
+      </p>
+      <div class="status-grid" aria-label="Project status">
+        <div>
+          <span>Build</span>
+          <strong>Vite + TypeScript</strong>
+        </div>
+        <div>
+          <span>Target</span>
+          <strong>Chrome / Edge</strong>
+        </div>
+        <div>
+          <span>Input</span>
+          <strong>Keyboard + Gamepad API</strong>
+        </div>
+      </div>
+    </section>
+  </main>
+`;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,102 @@
+:root {
+  color: #edf5ff;
+  background: #101820;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  min-width: 960px;
+  min-height: 100vh;
+  margin: 0;
+}
+
+body {
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    #101820;
+  background-size: 32px 32px;
+}
+
+.app-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 48px;
+}
+
+.title-screen {
+  width: min(100%, 920px);
+  border: 1px solid rgba(237, 245, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(16, 24, 32, 0.86);
+  padding: 56px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: #79d3c8;
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  color: #ffffff;
+  font-size: 4rem;
+  line-height: 1;
+}
+
+.summary {
+  max-width: 660px;
+  margin: 24px 0 0;
+  color: #b7c7d7;
+  font-size: 1.1rem;
+  line-height: 1.65;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 40px;
+}
+
+.status-grid div {
+  min-height: 112px;
+  border: 1px solid rgba(237, 245, 255, 0.14);
+  border-radius: 8px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.status-grid span {
+  display: block;
+  color: #8aa1b5;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.status-grid strong {
+  display: block;
+  margin-top: 14px;
+  color: #f4f8fb;
+  font-size: 1.05rem;
+  line-height: 1.35;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: process.env.BASE_PATH ?? '/',
+});


### PR DESCRIPTION
## Summary
- Set up the initial Vite + TypeScript static web app structure
- Add the first browser-rendered `Falling Blocks` screen
- Add baseline project scripts and ignore rules
- Update README with the current development commands and project constraints

Closes #1

## Validation
- `npm run build`
- `npm run test`

## Notes
Local `git push` failed because the configured local GitHub credential is `TakuyaKondo335`, which does not have push permission to `taku335/game_tetris_like`. The branch and PR were created through the GitHub connector instead.