### PR TITLE
[codex] Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+        env:
+          BASE_PATH: /game_tetris_like/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ npm run preview
 - サーバーサイド処理は使いません
 - PCブラウザの Chrome / Edge を優先します
 - 任天堂・公式テトリスの画像、音源、ロゴ、商標表現は使いません
+
+## GitHub Pages
+
+`main` ブランチに反映されると、GitHub Actions が `BASE_PATH=/game_tetris_like/` を指定してビルドし、`dist` を GitHub Pages にデプロイします。


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for GitHub Pages deployment
- Build with `BASE_PATH=/game_tetris_like/` for repository subpath hosting
- Upload `dist` as the Pages artifact and deploy with official Pages actions
- Document the Pages deployment behavior in README

Closes #3

## Validation
- `BASE_PATH=/game_tetris_like/ npm run build`
- `make build`
- `make test`
- Confirmed built `dist/index.html` references `/game_tetris_like/assets/...`

## Notes
This PR is stacked on #17 because it depends on the scaffold and make workflow from earlier issues.