### PR TITLE
[codex] Add screen layout flow

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,254 @@
 import './styles/app.css';
 
+type Screen = 'title' | 'game' | 'pause' | 'gameOver' | 'controls';
+
 const app = document.querySelector<HTMLDivElement>('#app');
 
 if (!app) {
   throw new Error('App root element was not found.');
 }
 
-app.innerHTML = `
-  <main class="app-shell" aria-labelledby="app-title">
-    <section class="title-screen">
+const root = app;
+
+let currentScreen: Screen = 'title';
+let previousScreen: Screen = 'title';
+
+const setScreen = (screen: Screen): void => {
+  if (screen !== 'pause' && screen !== 'controls') {
+    previousScreen = screen;
+  }
+  currentScreen = screen;
+  render();
+};
+
+const openControls = (): void => {
+  previousScreen = currentScreen;
+  currentScreen = 'controls';
+  render();
+};
+
+const renderBoardCells = (): string =>
+  Array.from({ length: 200 }, (_, index) => {
+    const sample = [4, 14, 24, 25, 156, 166, 176, 177, 188, 189].includes(index)
+      ? ' is-filled'
+      : '';
+    return `<span class="board-cell${sample}" aria-hidden="true"></span>`;
+  }).join('');
+
+const renderMiniCells = (filled: number[]): string =>
+  Array.from({ length: 16 }, (_, index) => {
+    const sample = filled.includes(index) ? ' is-filled' : '';
+    return `<span class="mini-cell${sample}" aria-hidden="true"></span>`;
+  }).join('');
+
+const renderTitle = (): string => `
+  <main class="screen title-screen" aria-labelledby="app-title">
+    <div class="title-copy">
       <p class="eyebrow">PC Browser Puzzle</p>
       <h1 id="app-title">Falling Blocks</h1>
-      <p class="summary">
-        A static web app foundation for a keyboard and Gamepad API controlled
-        falling block puzzle game.
-      </p>
-      <div class="status-grid" aria-label="Project status">
-        <div>
-          <span>Build</span>
-          <strong>Vite + TypeScript</strong>
-        </div>
-        <div>
-          <span>Target</span>
-          <strong>Chrome / Edge</strong>
-        </div>
-        <div>
-          <span>Input</span>
-          <strong>Keyboard + Gamepad API</strong>
-        </div>
+      <p class="summary">Keyboard and Gamepad API ready static web game.</p>
+    </div>
+    <nav class="menu-actions" aria-label="Title menu">
+      <button type="button" data-action="start">Start Game</button>
+      <button type="button" data-action="controls">Controls</button>
+    </nav>
+    <dl class="status-grid" aria-label="Status">
+      <div>
+        <dt>Keyboard</dt>
+        <dd>Ready</dd>
       </div>
-    </section>
+      <div>
+        <dt>Gamepad</dt>
+        <dd>Not Connected</dd>
+      </div>
+      <div>
+        <dt>High Score</dt>
+        <dd>000000</dd>
+      </div>
+    </dl>
   </main>
 `;
+
+const renderGame = (overlay?: 'pause' | 'gameOver'): string => `
+  <main class="game-shell" aria-labelledby="game-title">
+    <header class="game-header">
+      <h1 id="game-title">Falling Blocks</h1>
+      <div class="header-status">
+        <span>Keyboard: Ready</span>
+        <span>Gamepad: Not Connected</span>
+      </div>
+    </header>
+
+    <section class="game-layout" aria-label="Game layout">
+      <aside class="side-panel">
+        <section class="panel">
+          <h2>Hold</h2>
+          <div class="mini-board" aria-label="Hold block preview">
+            ${renderMiniCells([1, 5, 9, 13])}
+          </div>
+        </section>
+        <section class="panel stats-panel">
+          <h2>Score</h2>
+          <strong>012340</strong>
+          <h2>Lines</h2>
+          <strong>18</strong>
+        </section>
+      </aside>
+
+      <section class="board-wrap" aria-label="Main board">
+        <div class="board-grid">${renderBoardCells()}</div>
+      </section>
+
+      <aside class="side-panel">
+        <section class="panel">
+          <h2>Next</h2>
+          <div class="mini-board" aria-label="Next block preview">
+            ${renderMiniCells([4, 5, 6, 9])}
+          </div>
+        </section>
+        <section class="panel stats-panel">
+          <h2>Level</h2>
+          <strong>03</strong>
+        </section>
+        <section class="panel controls-panel">
+          <h2>Controls</h2>
+          <p>Move: Left / Right</p>
+          <p>Rotate: Up / Z</p>
+          <p>Drop: Down / Space</p>
+          <p>Hold: C / Shift</p>
+        </section>
+      </aside>
+    </section>
+
+    <footer class="game-actions">
+      <button type="button" data-action="pause">Pause</button>
+      <button type="button" data-action="game-over">End Run</button>
+      <button type="button" data-action="title">Title</button>
+    </footer>
+
+    ${overlay === 'pause' ? renderPauseOverlay() : ''}
+    ${overlay === 'gameOver' ? renderGameOverOverlay() : ''}
+  </main>
+`;
+
+const renderPauseOverlay = (): string => `
+  <section class="modal-layer" role="dialog" aria-modal="true" aria-labelledby="pause-title">
+    <div class="modal-panel">
+      <h2 id="pause-title">Paused</h2>
+      <div class="modal-actions">
+        <button type="button" data-action="resume">Resume</button>
+        <button type="button" data-action="restart">Restart</button>
+        <button type="button" data-action="controls">Controls</button>
+        <button type="button" data-action="title">Title</button>
+      </div>
+    </div>
+  </section>
+`;
+
+const renderGameOverOverlay = (): string => `
+  <section class="modal-layer" role="dialog" aria-modal="true" aria-labelledby="game-over-title">
+    <div class="modal-panel score-modal">
+      <h2 id="game-over-title">Game Over</h2>
+      <dl>
+        <div><dt>Score</dt><dd>024500</dd></div>
+        <div><dt>Lines</dt><dd>42</dd></div>
+        <div><dt>Level</dt><dd>06</dd></div>
+        <div><dt>High Score</dt><dd>024500</dd></div>
+      </dl>
+      <div class="modal-actions">
+        <button type="button" data-action="restart">Restart</button>
+        <button type="button" data-action="title">Title</button>
+      </div>
+    </div>
+  </section>
+`;
+
+const renderControls = (): string => `
+  <main class="screen controls-screen" aria-labelledby="controls-title">
+    <header class="screen-header">
+      <p class="eyebrow">Input</p>
+      <h1 id="controls-title">Controls</h1>
+    </header>
+    <section class="controls-grid">
+      <article class="control-card">
+        <h2>Keyboard</h2>
+        <dl>
+          <div><dt>Left / A</dt><dd>Move Left</dd></div>
+          <div><dt>Right / D</dt><dd>Move Right</dd></div>
+          <div><dt>Down / S</dt><dd>Soft Drop</dd></div>
+          <div><dt>Up / W / X</dt><dd>Rotate Clockwise</dd></div>
+          <div><dt>Z</dt><dd>Rotate Counterclockwise</dd></div>
+          <div><dt>Space</dt><dd>Hard Drop</dd></div>
+          <div><dt>C / Shift</dt><dd>Hold</dd></div>
+          <div><dt>Esc / P</dt><dd>Pause</dd></div>
+        </dl>
+      </article>
+      <article class="control-card">
+        <h2>Controller</h2>
+        <dl>
+          <div><dt>D-Pad / Left Stick</dt><dd>Move / Soft Drop</dd></div>
+          <div><dt>A / B</dt><dd>Rotate</dd></div>
+          <div><dt>X / Y</dt><dd>Hard Drop</dd></div>
+          <div><dt>L / R</dt><dd>Hold</dd></div>
+          <div><dt>+</dt><dd>Pause</dd></div>
+        </dl>
+        <p class="connection-state">Gamepad Status: Not Connected</p>
+      </article>
+    </section>
+    <button type="button" data-action="back">Back</button>
+  </main>
+`;
+
+function render(): void {
+  if (currentScreen === 'title') {
+    root.innerHTML = renderTitle();
+  } else if (currentScreen === 'game') {
+    root.innerHTML = renderGame();
+  } else if (currentScreen === 'pause') {
+    root.innerHTML = renderGame('pause');
+  } else if (currentScreen === 'gameOver') {
+    root.innerHTML = renderGame('gameOver');
+  } else {
+    root.innerHTML = renderControls();
+  }
+}
+
+root.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const action = target.dataset.action;
+
+  if (action === 'start' || action === 'restart') {
+    setScreen('game');
+  } else if (action === 'controls') {
+    openControls();
+  } else if (action === 'pause') {
+    currentScreen = 'pause';
+    render();
+  } else if (action === 'resume') {
+    setScreen('game');
+  } else if (action === 'game-over') {
+    currentScreen = 'gameOver';
+    render();
+  } else if (action === 'title') {
+    setScreen('title');
+  } else if (action === 'back') {
+    setScreen(previousScreen === 'controls' ? 'title' : previousScreen);
+  }
+});
+
+window.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' || event.key.toLowerCase() === 'p') {
+    if (currentScreen === 'game') {
+      currentScreen = 'pause';
+      render();
+    } else if (currentScreen === 'pause') {
+      setScreen('game');
+    }
+  }
+});
+
+render();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17,7 +17,7 @@
 html,
 body,
 #app {
-  min-width: 960px;
+  min-width: 1040px;
   min-height: 100vh;
   margin: 0;
 }
@@ -30,20 +30,40 @@ body {
   background-size: 32px 32px;
 }
 
-.app-shell {
+button {
+  min-height: 44px;
+  border: 1px solid rgba(237, 245, 255, 0.22);
+  border-radius: 8px;
+  background: #edf5ff;
+  color: #101820;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+}
+
+button:hover {
+  background: #79d3c8;
+}
+
+.screen {
   display: grid;
   min-height: 100vh;
-  place-items: center;
+  align-content: center;
+  gap: 32px;
   padding: 48px;
 }
 
 .title-screen {
-  width: min(100%, 920px);
-  border: 1px solid rgba(237, 245, 255, 0.18);
-  border-radius: 8px;
-  background: rgba(16, 24, 32, 0.86);
-  padding: 56px;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+  grid-template-columns: minmax(0, 1fr) 260px;
+  grid-template-areas:
+    "copy actions"
+    "status status";
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.title-copy {
+  grid-area: copy;
 }
 
 .eyebrow {
@@ -55,48 +75,266 @@ body {
   text-transform: uppercase;
 }
 
-h1 {
+h1,
+h2,
+p,
+dl {
   margin: 0;
+}
+
+h1 {
   color: #ffffff;
   font-size: 4rem;
   line-height: 1;
 }
 
+h2 {
+  color: #ffffff;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+}
+
 .summary {
-  max-width: 660px;
-  margin: 24px 0 0;
+  max-width: 620px;
+  margin-top: 24px;
   color: #b7c7d7;
-  font-size: 1.1rem;
+  font-size: 1.15rem;
   line-height: 1.65;
 }
 
+.menu-actions {
+  grid-area: actions;
+  display: grid;
+  align-content: center;
+  gap: 14px;
+}
+
 .status-grid {
+  grid-area: status;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
-  margin-top: 40px;
+}
+
+.status-grid div,
+.panel,
+.control-card,
+.modal-panel {
+  border: 1px solid rgba(237, 245, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(16, 24, 32, 0.9);
 }
 
 .status-grid div {
   min-height: 112px;
-  border: 1px solid rgba(237, 245, 255, 0.14);
-  border-radius: 8px;
   padding: 18px;
-  background: rgba(255, 255, 255, 0.045);
 }
 
-.status-grid span {
-  display: block;
+dt {
   color: #8aa1b5;
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
 }
 
-.status-grid strong {
-  display: block;
-  margin-top: 14px;
+dd {
+  margin: 8px 0 0;
   color: #f4f8fb;
-  font-size: 1.05rem;
-  line-height: 1.35;
+  font-size: 1.08rem;
+  font-weight: 800;
+}
+
+.game-shell {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  grid-template-rows: auto 1fr auto;
+  gap: 20px;
+  padding: 28px 40px;
+}
+
+.game-header,
+.game-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.game-header h1 {
+  font-size: 1.5rem;
+}
+
+.header-status,
+.game-actions {
+  color: #b7c7d7;
+  font-size: 0.9rem;
+}
+
+.header-status {
+  display: flex;
+  gap: 18px;
+}
+
+.game-actions {
+  justify-content: center;
+}
+
+.game-actions button {
+  min-width: 128px;
+}
+
+.game-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(360px, 440px) 220px;
+  justify-content: center;
+  gap: 24px;
+  min-height: 0;
+}
+
+.side-panel {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.panel {
+  padding: 18px;
+}
+
+.stats-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.stats-panel strong {
+  color: #79d3c8;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.controls-panel {
+  display: grid;
+  gap: 8px;
+}
+
+.controls-panel p,
+.connection-state {
+  color: #b7c7d7;
+  font-size: 0.9rem;
+}
+
+.board-wrap {
+  display: grid;
+  place-items: center;
+}
+
+.board-grid {
+  display: grid;
+  width: min(100%, 440px);
+  aspect-ratio: 10 / 20;
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(20, 1fr);
+  border: 2px solid rgba(237, 245, 255, 0.28);
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.board-cell,
+.mini-cell {
+  border: 1px solid rgba(237, 245, 255, 0.08);
+}
+
+.board-cell.is-filled,
+.mini-cell.is-filled {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: #79d3c8;
+  box-shadow: inset 0 -3px 0 rgba(16, 24, 32, 0.3);
+}
+
+.mini-board {
+  display: grid;
+  width: 96px;
+  aspect-ratio: 1;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  margin-top: 14px;
+  border: 1px solid rgba(237, 245, 255, 0.18);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.modal-layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 40px;
+  background: rgba(16, 24, 32, 0.78);
+}
+
+.modal-panel {
+  width: min(100%, 420px);
+  padding: 32px;
+  text-align: center;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.36);
+}
+
+.modal-panel h2 {
+  font-size: 2.5rem;
+  text-transform: none;
+}
+
+.modal-actions {
+  display: grid;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.score-modal dl {
+  display: grid;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.score-modal dl div,
+.control-card dl div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.controls-screen {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.screen-header {
+  display: grid;
+  gap: 8px;
+}
+
+.controls-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.control-card {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+}
+
+.control-card dl {
+  display: grid;
+  gap: 12px;
+}
+
+.control-card dd {
+  color: #edf5ff;
+  font-size: 0.96rem;
+}
+
+.controls-screen > button {
+  width: 180px;
 }


### PR DESCRIPTION
## Summary
- Add screen state routing for title, game, pause, game over, and controls screens
- Build a PC-oriented game layout with board, Hold, Next, score, lines, level, controls, and connection status areas
- Add modal overlays for pause and game over
- Replace the initial placeholder styling with the full app layout styles

Closes #4

## Validation
- `make build`
- `make test`

## Notes
This PR is stacked on #18 because it depends on the prior scaffold, Docker workflow, and Pages setup.