### PR TITLE
[codex] Add tests and verification checklist

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,50 @@
+# Verification Checklist
+
+## Automated Checks
+
+```bash
+make build
+make test
+```
+
+`make test` runs TypeScript type checking and Vitest unit tests.
+
+## Browser Smoke Check
+
+1. Run `make preview`.
+2. Open `http://localhost:4173/` in Chrome or Edge.
+3. Start a game from the title screen.
+4. Confirm the board, Hold, Next, Score, Lines, Level, and Gamepad status areas render.
+5. Confirm restart returns the game to a clean board.
+6. Confirm title navigation returns to the title screen.
+
+## Keyboard Check
+
+1. Move left and right with `Left` / `Right`.
+2. Soft drop with `Down`.
+3. Rotate with `Up` and `Z`.
+4. Hard drop with `Space`.
+5. Hold with `C` or `Shift`.
+6. Pause and resume with `Esc` or `P`.
+
+## Gamepad / Pro Controller Check
+
+1. Pair the Nintendo Switch Pro Controller with the PC over Bluetooth.
+2. Open the app in Chrome or Edge.
+3. Confirm Gamepad Status changes to `Connected`.
+4. Move with the D-pad or left stick.
+5. Soft drop with D-pad down or left stick down.
+6. Rotate with `A` / `B`.
+7. Hard drop with `X` / `Y`.
+8. Hold with `L` / `R`.
+9. Pause with `+`.
+
+Button numbers can vary by OS and browser. If a physical controller differs, update the mapping arrays in `src/game/input.ts`.
+
+## GitHub Pages Check
+
+1. Merge the target branch into `main`.
+2. Confirm the GitHub Pages workflow completes successfully.
+3. Open the Pages URL.
+4. Confirm JS and CSS load from the `/game_tetris_like/` base path.
+5. Run the browser and input checks against the deployed page.

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "tsc --noEmit"
+    "test": "tsc --noEmit && vitest run"
   },
   "devDependencies": {
     "typescript": "^5.8.3",
-    "vite": "^6.3.0"
+    "vite": "^6.3.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/game/input.test.ts
+++ b/src/game/input.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { gamepadAxisMap, gamepadButtonMap, keyboardMap } from './input';
+
+describe('input mappings', () => {
+  it('maps keyboard controls to every gameplay action', () => {
+    expect(keyboardMap.get('ArrowLeft')).toBe('moveLeft');
+    expect(keyboardMap.get('ArrowRight')).toBe('moveRight');
+    expect(keyboardMap.get('ArrowDown')).toBe('softDrop');
+    expect(keyboardMap.get('Space')).toBe('hardDrop');
+    expect(keyboardMap.get('ArrowUp')).toBe('rotateClockwise');
+    expect(keyboardMap.get('KeyZ')).toBe('rotateCounterclockwise');
+    expect(keyboardMap.get('KeyC')).toBe('hold');
+    expect(keyboardMap.get('Escape')).toBe('pause');
+  });
+
+  it('marks movement and soft drop gamepad buttons as repeatable', () => {
+    expect(gamepadButtonMap).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: 'moveLeft', repeat: true }),
+        expect.objectContaining({ action: 'moveRight', repeat: true }),
+        expect.objectContaining({ action: 'softDrop', repeat: true }),
+      ]),
+    );
+  });
+
+  it('keeps one-shot gamepad actions non-repeatable', () => {
+    expect(gamepadButtonMap).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: 'hardDrop', repeat: false }),
+        expect.objectContaining({ action: 'hold', repeat: false }),
+        expect.objectContaining({ action: 'pause', repeat: false }),
+      ]),
+    );
+  });
+
+  it('maps left stick axes to movement and soft drop', () => {
+    expect(gamepadAxisMap).toEqual(
+      expect.arrayContaining([
+        { axis: 0, direction: -1, action: 'moveLeft' },
+        { axis: 0, direction: 1, action: 'moveRight' },
+        { axis: 1, direction: 1, action: 'softDrop' },
+      ]),
+    );
+  });
+});

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -1,0 +1,59 @@
+export type InputAction =
+  | 'moveLeft'
+  | 'moveRight'
+  | 'softDrop'
+  | 'hardDrop'
+  | 'rotateClockwise'
+  | 'rotateCounterclockwise'
+  | 'hold'
+  | 'pause';
+
+export type GamepadButtonBinding = {
+  button: number;
+  action: InputAction;
+  repeat: boolean;
+};
+
+export type GamepadAxisBinding = {
+  axis: number;
+  direction: -1 | 1;
+  action: InputAction;
+};
+
+export const keyboardMap = new Map<string, InputAction>([
+  ['ArrowLeft', 'moveLeft'],
+  ['KeyA', 'moveLeft'],
+  ['ArrowRight', 'moveRight'],
+  ['KeyD', 'moveRight'],
+  ['ArrowDown', 'softDrop'],
+  ['KeyS', 'softDrop'],
+  ['Space', 'hardDrop'],
+  ['ArrowUp', 'rotateClockwise'],
+  ['KeyW', 'rotateClockwise'],
+  ['KeyX', 'rotateClockwise'],
+  ['KeyZ', 'rotateCounterclockwise'],
+  ['KeyC', 'hold'],
+  ['ShiftLeft', 'hold'],
+  ['ShiftRight', 'hold'],
+  ['Escape', 'pause'],
+  ['KeyP', 'pause'],
+]);
+
+export const gamepadButtonMap: GamepadButtonBinding[] = [
+  { button: 14, action: 'moveLeft', repeat: true },
+  { button: 15, action: 'moveRight', repeat: true },
+  { button: 13, action: 'softDrop', repeat: true },
+  { button: 0, action: 'rotateClockwise', repeat: false },
+  { button: 1, action: 'rotateCounterclockwise', repeat: false },
+  { button: 2, action: 'hardDrop', repeat: false },
+  { button: 3, action: 'hardDrop', repeat: false },
+  { button: 4, action: 'hold', repeat: false },
+  { button: 5, action: 'hold', repeat: false },
+  { button: 9, action: 'pause', repeat: false },
+];
+
+export const gamepadAxisMap: GamepadAxisBinding[] = [
+  { axis: 0, direction: -1, action: 'moveLeft' },
+  { axis: 0, direction: 1, action: 'moveRight' },
+  { axis: 1, direction: 1, action: 'softDrop' },
+];

--- a/src/game/rules.test.ts
+++ b/src/game/rules.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateDropInterval,
+  calculateLevel,
+  calculateLineClearScore,
+  clearCompletedRows,
+} from './rules';
+import type { Cell } from './rules';
+
+describe('game rules', () => {
+  it('clears completed rows and keeps remaining rows in order', () => {
+    const cells: Cell[] = [
+      null, 'a', null, 'b',
+      'c', 'c', 'c', 'c',
+      'd', null, null, 'd',
+      'e', 'e', 'e', 'e',
+    ];
+
+    const result = clearCompletedRows(cells, 4, 4);
+
+    expect(result.cleared).toBe(2);
+    expect(result.cells).toEqual([
+      null, null, null, null,
+      null, null, null, null,
+      null, 'a', null, 'b',
+      'd', null, null, 'd',
+    ]);
+  });
+
+  it('does not allocate a changed board when no rows are complete', () => {
+    const cells: Cell[] = [null, 'a', 'b', null];
+
+    const result = clearCompletedRows(cells, 2, 2);
+
+    expect(result.cleared).toBe(0);
+    expect(result.cells).toBe(cells);
+  });
+
+  it('calculates level from total cleared lines', () => {
+    expect(calculateLevel(0)).toBe(1);
+    expect(calculateLevel(9)).toBe(1);
+    expect(calculateLevel(10)).toBe(2);
+    expect(calculateLevel(29)).toBe(3);
+  });
+
+  it('calculates line clear score using level multiplier', () => {
+    expect(calculateLineClearScore(1, 1)).toBe(100);
+    expect(calculateLineClearScore(2, 2)).toBe(600);
+    expect(calculateLineClearScore(4, 3)).toBe(2400);
+  });
+
+  it('reduces drop interval by level without going under the minimum', () => {
+    expect(calculateDropInterval(1, 650, 120)).toBe(650);
+    expect(calculateDropInterval(3, 650, 120)).toBe(540);
+    expect(calculateDropInterval(99, 650, 120)).toBe(120);
+  });
+});

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -1,0 +1,43 @@
+export type Cell = string | null;
+
+const defaultLineScores = [0, 100, 300, 500, 800];
+
+export const calculateLevel = (lines: number): number => Math.floor(lines / 10) + 1;
+
+export const calculateDropInterval = (
+  level: number,
+  baseDropIntervalMs = 650,
+  minDropIntervalMs = 120,
+): number => Math.max(minDropIntervalMs, baseDropIntervalMs - (level - 1) * 55);
+
+export const calculateLineClearScore = (cleared: number, level: number): number => {
+  const baseScore = defaultLineScores[cleared] ?? cleared * 200;
+  return baseScore * level;
+};
+
+export const clearCompletedRows = (
+  cells: Cell[],
+  columns: number,
+  rows: number,
+): { cells: Cell[]; cleared: number } => {
+  const remainingRows: Cell[][] = [];
+  let cleared = 0;
+
+  for (let row = 0; row < rows; row += 1) {
+    const start = row * columns;
+    const rowCells = cells.slice(start, start + columns);
+
+    if (rowCells.every((cell) => cell !== null)) {
+      cleared += 1;
+    } else {
+      remainingRows.push(rowCells);
+    }
+  }
+
+  if (cleared === 0) {
+    return { cells, cleared };
+  }
+
+  const emptyRows = Array.from({ length: cleared }, () => Array<Cell>(columns).fill(null));
+  return { cells: [...emptyRows, ...remainingRows].flat(), cleared };
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,15 @@
 import './styles/app.css';
+import { gamepadAxisMap, gamepadButtonMap, keyboardMap } from './game/input';
+import type { InputAction } from './game/input';
+import {
+  calculateDropInterval,
+  calculateLevel,
+  calculateLineClearScore,
+  clearCompletedRows,
+} from './game/rules';
+import type { Cell } from './game/rules';
 
 type Screen = 'title' | 'game' | 'pause' | 'gameOver' | 'controls';
-type Cell = string | null;
 type Point = { x: number; y: number };
 type Piece = {
   definition: PieceDefinition;
@@ -13,25 +21,6 @@ type Piece = {
 type PieceDefinition = {
   cells: Point[];
   color: string;
-};
-type InputAction =
-  | 'moveLeft'
-  | 'moveRight'
-  | 'softDrop'
-  | 'hardDrop'
-  | 'rotateClockwise'
-  | 'rotateCounterclockwise'
-  | 'hold'
-  | 'pause';
-type GamepadButtonBinding = {
-  button: number;
-  action: InputAction;
-  repeat: boolean;
-};
-type GamepadAxisBinding = {
-  axis: number;
-  direction: -1 | 1;
-  action: InputAction;
 };
 type GamepadConnectionState = 'waiting' | 'connected' | 'disconnected' | 'unsupported';
 
@@ -98,41 +87,6 @@ let lastDropTime = 0;
 let score = 0;
 let lines = 0;
 let level = 1;
-const keyboardMap = new Map<string, InputAction>([
-  ['ArrowLeft', 'moveLeft'],
-  ['KeyA', 'moveLeft'],
-  ['ArrowRight', 'moveRight'],
-  ['KeyD', 'moveRight'],
-  ['ArrowDown', 'softDrop'],
-  ['KeyS', 'softDrop'],
-  ['Space', 'hardDrop'],
-  ['ArrowUp', 'rotateClockwise'],
-  ['KeyW', 'rotateClockwise'],
-  ['KeyX', 'rotateClockwise'],
-  ['KeyZ', 'rotateCounterclockwise'],
-  ['KeyC', 'hold'],
-  ['ShiftLeft', 'hold'],
-  ['ShiftRight', 'hold'],
-  ['Escape', 'pause'],
-  ['KeyP', 'pause'],
-]);
-const gamepadButtonMap: GamepadButtonBinding[] = [
-  { button: 14, action: 'moveLeft', repeat: true },
-  { button: 15, action: 'moveRight', repeat: true },
-  { button: 13, action: 'softDrop', repeat: true },
-  { button: 0, action: 'rotateClockwise', repeat: false },
-  { button: 1, action: 'rotateCounterclockwise', repeat: false },
-  { button: 2, action: 'hardDrop', repeat: false },
-  { button: 3, action: 'hardDrop', repeat: false },
-  { button: 4, action: 'hold', repeat: false },
-  { button: 5, action: 'hold', repeat: false },
-  { button: 9, action: 'pause', repeat: false },
-];
-const gamepadAxisMap: GamepadAxisBinding[] = [
-  { axis: 0, direction: -1, action: 'moveLeft' },
-  { axis: 0, direction: 1, action: 'moveRight' },
-  { axis: 1, direction: 1, action: 'softDrop' },
-];
 const pressedGamepadButtons = new Set<number>();
 const buttonRepeatTimes = new Map<string, number>();
 const axisRepeatTimes = new Map<string, number>();
@@ -290,40 +244,24 @@ const resetGame = (): void => {
 };
 
 const getDropInterval = (): number =>
-  Math.max(minDropIntervalMs, baseDropIntervalMs - (level - 1) * 55);
+  calculateDropInterval(level, baseDropIntervalMs, minDropIntervalMs);
 
 const addScore = (points: number): void => {
   score += points * level;
 };
 
 const clearCompletedLines = (): void => {
-  const remainingRows: Cell[][] = [];
-  let cleared = 0;
-
-  for (let row = 0; row < boardRows; row += 1) {
-    const start = row * boardColumns;
-    const rowCells = boardCells.slice(start, start + boardColumns);
-
-    if (rowCells.every((cell) => cell !== null)) {
-      cleared += 1;
-    } else {
-      remainingRows.push(rowCells);
-    }
-  }
+  const result = clearCompletedRows(boardCells, boardColumns, boardRows);
+  const { cleared } = result;
 
   if (cleared === 0) {
     return;
   }
 
-  const emptyRows = Array.from({ length: cleared }, () =>
-    Array<Cell>(boardColumns).fill(null),
-  );
-  boardCells = [...emptyRows, ...remainingRows].flat();
+  boardCells = result.cells;
   lines += cleared;
-  level = Math.floor(lines / 10) + 1;
-
-  const lineScores = [0, 100, 300, 500, 800];
-  addScore(lineScores[cleared] ?? cleared * 200);
+  level = calculateLevel(lines);
+  score += calculateLineClearScore(cleared, level);
 };
 
 const lockPiece = (piece: Piece): void => {


### PR DESCRIPTION
## Summary
- add Vitest and run it from `make test` through the npm test script
- extract game rule and input mapping helpers for focused unit tests
- add tests for line clears, scoring, level/drop speed, and keyboard/gamepad mappings
- add a manual verification checklist for browser, keyboard, Gamepad API, and GitHub Pages checks

## Validation
- `make install`
- `make build`
- `make test` (2 files, 9 tests)

Stacked on #30.
Closes #15.