### PR TITLE
[codex] Deduplicate gamepad movement actions

### DIFF
--- a/src/game/input.test.ts
+++ b/src/game/input.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { gamepadAxisMap, gamepadButtonMap, keyboardMap } from './input';
+import {
+  gamepadAxisMap,
+  gamepadButtonMap,
+  keyboardMap,
+  shouldApplyGamepadAction,
+} from './input';
+import type { InputAction } from './input';
 
 describe('input mappings', () => {
   it('maps keyboard controls to every gameplay action', () => {
@@ -41,5 +47,13 @@ describe('input mappings', () => {
         { axis: 1, direction: 1, action: 'softDrop' },
       ]),
     );
+  });
+
+  it('deduplicates duplicate gamepad actions in one polling frame', () => {
+    const appliedActions = new Set<InputAction>();
+
+    expect(shouldApplyGamepadAction(appliedActions, 'moveLeft')).toBe(true);
+    expect(shouldApplyGamepadAction(appliedActions, 'moveLeft')).toBe(false);
+    expect(shouldApplyGamepadAction(appliedActions, 'moveRight')).toBe(true);
   });
 });

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -57,3 +57,15 @@ export const gamepadAxisMap: GamepadAxisBinding[] = [
   { axis: 0, direction: 1, action: 'moveRight' },
   { axis: 1, direction: 1, action: 'softDrop' },
 ];
+
+export const shouldApplyGamepadAction = (
+  appliedActions: Set<InputAction>,
+  action: InputAction,
+): boolean => {
+  if (appliedActions.has(action)) {
+    return false;
+  }
+
+  appliedActions.add(action);
+  return true;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,10 @@
 import './styles/app.css';
-import { gamepadAxisMap, gamepadButtonMap, keyboardMap } from './game/input';
+import {
+  gamepadAxisMap,
+  gamepadButtonMap,
+  keyboardMap,
+  shouldApplyGamepadAction,
+} from './game/input';
 import type { InputAction } from './game/input';
 import {
   calculateDropInterval,
@@ -457,7 +462,20 @@ const shouldApplyRepeatedInput = (
   return true;
 };
 
-const pollGamepadButtons = (gamepad: Gamepad, timestamp: number): void => {
+const applyGamepadAction = (
+  appliedActions: Set<InputAction>,
+  action: InputAction,
+): void => {
+  if (shouldApplyGamepadAction(appliedActions, action)) {
+    applyInputAction(action);
+  }
+};
+
+const pollGamepadButtons = (
+  gamepad: Gamepad,
+  timestamp: number,
+  appliedActions: Set<InputAction>,
+): void => {
   gamepadButtonMap.forEach((binding) => {
     const pressed = gamepad.buttons[binding.button]?.pressed ?? false;
     const wasPressed = pressedGamepadButtons.has(binding.button);
@@ -469,20 +487,24 @@ const pollGamepadButtons = (gamepad: Gamepad, timestamp: number): void => {
     }
 
     if (!binding.repeat && !wasPressed) {
-      applyInputAction(binding.action);
+      applyGamepadAction(appliedActions, binding.action);
     } else if (
       binding.repeat &&
       (!wasPressed ||
         shouldApplyRepeatedInput(String(binding.button), timestamp, buttonRepeatTimes))
     ) {
-      applyInputAction(binding.action);
+      applyGamepadAction(appliedActions, binding.action);
     }
 
     pressedGamepadButtons.add(binding.button);
   });
 };
 
-const pollGamepadAxes = (gamepad: Gamepad, timestamp: number): void => {
+const pollGamepadAxes = (
+  gamepad: Gamepad,
+  timestamp: number,
+  appliedActions: Set<InputAction>,
+): void => {
   gamepadAxisMap.forEach((binding) => {
     const value = gamepad.axes[binding.axis] ?? 0;
     const active =
@@ -497,7 +519,7 @@ const pollGamepadAxes = (gamepad: Gamepad, timestamp: number): void => {
     }
 
     if (shouldApplyRepeatedInput(key, timestamp, axisRepeatTimes)) {
-      applyInputAction(binding.action);
+      applyGamepadAction(appliedActions, binding.action);
     }
   });
 };
@@ -508,8 +530,9 @@ const pollGamepads = (timestamp: number): void => {
     return;
   }
 
-  pollGamepadButtons(gamepad, timestamp);
-  pollGamepadAxes(gamepad, timestamp);
+  const appliedActions = new Set<InputAction>();
+  pollGamepadButtons(gamepad, timestamp, appliedActions);
+  pollGamepadAxes(gamepad, timestamp, appliedActions);
 };
 
 const updateGame = (timestamp: number): void => {


### PR DESCRIPTION
## Summary
- Deduplicate same gamepad actions within one animation frame so D-pad button and axis reports do not move two cells at once.
- Keep repeat timing behavior intact while sharing the per-frame applied action set across button and axis polling.
- Add a unit test for the deduplication helper.

## Validation
- `make build`
- `make test`

## Notes
- Physical Nintendo Switch Pro Controller validation still needs to be checked on the target PC/browser because this environment cannot access the Bluetooth controller.