### PR TITLE
[codex] Integrate procon mapper input

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           node-version: 22
 
+      - name: Prefer HTTPS for GitHub dependencies
+        run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Install dependencies
         run: npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+RUN apk add --no-cache git
+RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" \
+  && git config --global url."https://github.com/".insteadOf "git@github.com:"
+
 COPY package*.json ./
 RUN npm install
 

--- a/README.md
+++ b/README.md
@@ -66,20 +66,22 @@ npm run preview
 
 ### Nintendo Switch Proコントローラー
 
-Gamepad API で入力を取得します。Bluetooth接続したPCで、Chrome / Edge の利用を想定しています。
+Gamepad API の入力を `procon-gamepad-mapper` 経由で取得します。Bluetooth接続したPCで、Chrome / Edge の利用を想定しています。
+
+現時点で `procon-gamepad-mapper` は npm 未公開のため、GitHub の HTTPS 参照を依存関係として導入しています。
 
 | 操作 | 割り当て案 |
 | --- | --- |
 | 左右移動 | 十字キー / 左スティック |
 | ソフトドロップ | 十字キー下 / 左スティック下 |
+| ハードドロップ | 十字キー上 / `X` / `Y` |
 | 回転 | `A` / `B` |
-| ハードドロップ | `X` / `Y` |
-| Hold | `L` / `R` |
+| Hold | `L` / `R` / `ZL` / `ZR` |
 | Pause | `+` |
 
-OS、ブラウザ、接続状態によってボタン番号が異なる場合があります。現在は設定配列でマッピングを差し替えやすい構造にしており、将来的なキーコンフィグ実装を想定しています。
+ゲーム本体側では物理ボタン番号や axis index を直接扱わず、`moveLeft`、`rotateCW`、`pause` などの抽象アクションだけを参照します。
 
-タイトル画面は十字キーまたは左スティックでメニューを選択し、`A` または `+` で決定できます。操作説明画面では接続状態、コントローラー名、十字キー、左スティック、ボタン入力をリアルタイム表示します。
+タイトル画面は十字キーまたは左スティックでメニューを選択し、`A` または `+` で決定できます。操作説明画面では接続中の gamepad、選択中の controller、入力状態、mapped action、dead zone、保存済み設定の状態をリアルタイム表示します。
 
 ## Proコン接続手順
 
@@ -90,6 +92,8 @@ OS、ブラウザ、接続状態によってボタン番号が異なる場合が
 5. ゲーム画面または操作説明画面の Gamepad Status が `Connected` になることを確認します。
 
 接続済みでも入力されない場合は、ブラウザを再読み込みするか、コントローラーの再接続を試してください。
+
+Windows / macOS、Chrome / Edge、Bluetooth / USB、コントローラーのファームウェア差によって、Gamepad API の `id` や列挙タイミングが変わる場合があります。ブラウザによっては、コントローラーのボタンを一度押すまで gamepad が列挙されません。GitHub Pages は HTTPS の secure context で配信されるため Gamepad API の利用に適しています。
 
 ## 実装済み機能
 
@@ -109,8 +113,10 @@ OS、ブラウザ、接続状態によってボタン番号が異なる場合が
 - 操作説明画面
 - Gamepad API 接続状態表示
 - タイトル画面のゲームパッド操作
-- コントローラー入力の可視化
+- procon-gamepad-mapper 経由のコントローラー入力
+- コントローラー入力と mapped action の可視化
 - localStorage によるハイスコア保存
+- localStorage によるコントローラー設定保存状態の表示
 
 ## GitHub Pages
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -39,21 +39,22 @@ make test
 7. Move left and right with the left stick and confirm it matches the D-pad behavior.
 8. Hold left or right and confirm movement repeats after a short delay at a steady interval.
 9. Soft drop with D-pad down or left stick down.
-10. Rotate with `A` / `B`.
-11. Hard drop with `X` / `Y`.
-12. Hold with `L` / `R`.
+10. Hard drop with D-pad up / `X` / `Y`.
+11. Rotate clockwise with `A` and counterclockwise with `B`.
+12. Hold with `L` / `R` / `ZL` / `ZR`.
 13. Pause with `+`.
 
 ## Controller Diagnostics Check
 
 1. Open the Controls screen.
-2. Confirm connection status and controller name are displayed.
-3. Press each D-pad direction and confirm the matching button indicator updates.
-4. Move the left stick and confirm the stick dot and axis values update in real time.
-5. Press `A` / `B` / `X` / `Y` / `L` / `R` / `+` and confirm button indicators update.
-6. If one physical input activates multiple sources, confirm the direction monitor shows multiple source pills.
+2. Confirm connection status, connected gamepad list, selected controller, and Pro Controller confidence are displayed.
+3. Confirm dead zone and saved settings state are displayed.
+4. Press each D-pad direction and confirm the named input state updates.
+5. Move the left stick and confirm the named stick direction input updates.
+6. Press `A` / `B` / `X` / `Y` / `L` / `R` / `ZL` / `ZR` / `+` and confirm input state updates.
+7. Confirm mapped actions update without showing physical button numbers or axis indexes.
 
-Button numbers can vary by OS and browser. If a physical controller differs, update the mapping arrays in `src/game/input.ts`.
+Gamepad API data can vary by Windows / macOS, Chrome / Edge, Bluetooth / USB, browser version, and controller firmware. The game should continue to run if no Pro Controller is connected.
 
 ## GitHub Pages Check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1423 @@
+{
+  "name": "falling-blocks",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "falling-blocks",
+      "version": "0.1.0",
+      "dependencies": {
+        "procon-gamepad-mapper": "git+https://github.com/taku335/procon-gamepad-mapper.git#1085effbebfec74016665371414f270250f9a539"
+      },
+      "devDependencies": {
+        "typescript": "^5.8.3",
+        "vite": "^6.3.0",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/procon-gamepad-mapper": {
+      "version": "0.1.0",
+      "resolved": "git+https://github.com/taku335/procon-gamepad-mapper.git#1085effbebfec74016665371414f270250f9a539",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "preview": "vite preview",
     "test": "tsc --noEmit && vitest run"
   },
+  "dependencies": {
+    "procon-gamepad-mapper": "git+https://github.com/taku335/procon-gamepad-mapper.git#1085effbebfec74016665371414f270250f9a539"
+  },
   "devDependencies": {
     "typescript": "^5.8.3",
     "vite": "^6.3.0",

--- a/src/game/input.test.ts
+++ b/src/game/input.test.ts
@@ -1,32 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
-  collectGamepadActionStates,
+  collectControllerActionStates,
   collectKeyboardActionStates,
+  controllerActionMapping,
+  createEmptyControllerDebugSnapshot,
   createInputTimingState,
-  gamepadAxisMap,
-  gamepadButtonMap,
+  dedupeActions,
+  defaultControllerDeadZone,
+  filterControllerEdgeActions,
   keyboardMap,
   keyboardMenuMap,
+  oneShotControllerActions,
+  repeatableActions,
   resolveTriggeredActions,
-  shouldApplyGamepadAction,
 } from './input';
-import type { InputAction } from './input';
-
-const createButton = (pressed = false, value = pressed ? 1 : 0): GamepadButton => ({
-  pressed,
-  touched: pressed,
-  value,
-});
-
-const createGamepad = (
-  axes: number[],
-  pressedButtons: number[],
-): Pick<Gamepad, 'axes' | 'buttons' | 'id' | 'index'> => ({
-  axes,
-  buttons: Array.from({ length: 16 }, (_, index) => createButton(pressedButtons.includes(index))),
-  id: 'Test Controller',
-  index: 0,
-});
 
 describe('input mappings', () => {
   it('maps keyboard controls to every gameplay action', () => {
@@ -34,8 +21,8 @@ describe('input mappings', () => {
     expect(keyboardMap.get('ArrowRight')).toBe('moveRight');
     expect(keyboardMap.get('ArrowDown')).toBe('softDrop');
     expect(keyboardMap.get('Space')).toBe('hardDrop');
-    expect(keyboardMap.get('ArrowUp')).toBe('rotateClockwise');
-    expect(keyboardMap.get('KeyZ')).toBe('rotateCounterclockwise');
+    expect(keyboardMap.get('ArrowUp')).toBe('rotateCW');
+    expect(keyboardMap.get('KeyZ')).toBe('rotateCCW');
     expect(keyboardMap.get('KeyC')).toBe('hold');
     expect(keyboardMap.get('Escape')).toBe('pause');
   });
@@ -47,52 +34,82 @@ describe('input mappings', () => {
     expect(keyboardMenuMap.get('Escape')).toBe('back');
   });
 
-  it('marks movement and soft drop gamepad buttons as repeatable', () => {
-    expect(gamepadButtonMap).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ action: 'moveLeft', repeat: true }),
-        expect.objectContaining({ action: 'moveRight', repeat: true }),
-        expect.objectContaining({ action: 'softDrop', repeat: true }),
-      ]),
+  it('maps controller gameplay actions through named physical inputs', () => {
+    expect(controllerActionMapping.moveLeft).toEqual(['dpadLeft', 'leftStickLeft']);
+    expect(controllerActionMapping.moveRight).toEqual(['dpadRight', 'leftStickRight']);
+    expect(controllerActionMapping.softDrop).toEqual(['dpadDown', 'leftStickDown']);
+    expect(controllerActionMapping.hardDrop).toEqual(['dpadUp', 'buttonX', 'buttonY']);
+    expect(controllerActionMapping.rotateCW).toBe('buttonA');
+    expect(controllerActionMapping.rotateCCW).toBe('buttonB');
+    expect(controllerActionMapping.hold).toEqual(['buttonL', 'buttonR', 'buttonZL', 'buttonZR']);
+    expect(controllerActionMapping.pause).toBe('buttonPlus');
+  });
+
+  it('keeps only movement and menu navigation repeatable', () => {
+    expect(repeatableActions).toEqual(
+      new Set(['moveLeft', 'moveRight', 'softDrop', 'menuPrevious', 'menuNext']),
     );
+    const oneShotActions = [
+      'hardDrop',
+      'rotateCW',
+      'rotateCCW',
+      'hold',
+      'pause',
+      'confirm',
+      'back',
+    ] as const;
+
+    oneShotActions.forEach((action) => {
+      expect(oneShotControllerActions.has(action)).toBe(true);
+    });
   });
 
-  it('keeps one-shot gamepad actions non-repeatable', () => {
-    expect(gamepadButtonMap).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ action: 'hardDrop', repeat: false }),
-        expect.objectContaining({ action: 'hold', repeat: false }),
-        expect.objectContaining({ action: 'pause', repeat: false }),
-      ]),
+  it('collects held controller actions for the active mode only', () => {
+    const states = collectControllerActionStates(
+      {
+        moveLeft: true,
+        moveRight: false,
+        softDrop: false,
+        hardDrop: true,
+        rotateCW: false,
+        rotateCCW: false,
+        hold: false,
+        pause: false,
+        menuPrevious: true,
+        menuNext: false,
+        confirm: false,
+        back: false,
+      },
+      'gameplay',
     );
+
+    expect(states.map((state) => state.action)).toEqual(['moveLeft']);
+    expect(states[0]?.sources.map((source) => source.id)).toEqual(['dpadLeft', 'leftStickLeft']);
   });
 
-  it('maps left stick axes to movement and soft drop', () => {
-    expect(gamepadAxisMap).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ axis: 0, direction: -1, action: 'moveLeft' }),
-        expect.objectContaining({ axis: 0, direction: 1, action: 'moveRight' }),
-        expect.objectContaining({ axis: 1, direction: 1, action: 'softDrop' }),
-      ]),
-    );
+  it('filters controller edge actions by active mode', () => {
+    expect(filterControllerEdgeActions(['pause', 'confirm', 'back'], 'gameplay')).toEqual(['pause']);
+    expect(filterControllerEdgeActions(['pause', 'confirm', 'back'], 'menu')).toEqual([
+      'confirm',
+      'back',
+    ]);
   });
 
-  it('deduplicates duplicate gamepad actions in one polling frame', () => {
-    const appliedActions = new Set<InputAction>();
-
-    expect(shouldApplyGamepadAction(appliedActions, 'moveLeft')).toBe(true);
-    expect(shouldApplyGamepadAction(appliedActions, 'moveLeft')).toBe(false);
-    expect(shouldApplyGamepadAction(appliedActions, 'moveRight')).toBe(true);
+  it('deduplicates repeated actions in one polling frame', () => {
+    expect(dedupeActions(['moveLeft', 'moveLeft', 'moveRight'])).toEqual([
+      'moveLeft',
+      'moveRight',
+    ]);
   });
 
-  it('collects duplicate button and axis sources as one action state', () => {
-    const gamepad = createGamepad([-0.8, 0], [14]);
-    const { states, snapshot } = collectGamepadActionStates(gamepad, 'gameplay', 0.55);
-    const left = states.find((state) => state.action === 'moveLeft');
+  it('creates an empty controller snapshot when the Gamepad API is unavailable', () => {
+    const snapshot = createEmptyControllerDebugSnapshot();
 
-    expect(left?.sources).toHaveLength(2);
-    expect(states.filter((state) => state.action === 'moveLeft')).toHaveLength(1);
-    expect(snapshot.activeActionSources.get('moveLeft')).toHaveLength(2);
+    expect(snapshot.connectedGamepads).toEqual([]);
+    expect(snapshot.selectedGamepad).toBeNull();
+    expect(snapshot.deadZone).toBe(defaultControllerDeadZone);
+    expect(snapshot.actions.moveLeft).toBe(false);
+    expect(snapshot.inputs.dpadLeft).toBe(false);
   });
 
   it('triggers held movement once, waits for repeat delay, then repeats by interval', () => {
@@ -131,7 +148,7 @@ describe('input mappings', () => {
     ).toEqual(['moveLeft']);
   });
 
-  it('does not repeat one-shot actions while held', () => {
+  it('does not repeat one-shot keyboard actions while held', () => {
     const timing = createInputTimingState();
     const states = [{ action: 'hardDrop' as const, pressed: true, sources: [] }];
 

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -1,17 +1,28 @@
+import { createProconMapper } from 'procon-gamepad-mapper';
+import type {
+  ActionMapping,
+  ActionState,
+  DetectedGamepad,
+  PhysicalInputState,
+  ProconMapper,
+  ProconPhysicalInput,
+} from 'procon-gamepad-mapper';
+
 export type GameplayAction =
   | 'moveLeft'
   | 'moveRight'
   | 'softDrop'
   | 'hardDrop'
-  | 'rotateClockwise'
-  | 'rotateCounterclockwise'
+  | 'rotateCW'
+  | 'rotateCCW'
   | 'hold'
   | 'pause';
 
 export type MenuAction = 'menuPrevious' | 'menuNext' | 'confirm' | 'back';
 export type InputAction = GameplayAction | MenuAction;
 export type InputMode = 'gameplay' | 'menu';
-export type InputSourceType = 'keyboard' | 'gamepadButton' | 'gamepadAxis';
+export type InputSourceType = 'keyboard' | 'controller';
+export type SavedControllerConfigState = 'loaded' | 'default';
 
 export type InputSource = {
   type: InputSourceType;
@@ -36,57 +47,59 @@ export type InputRepeatOptions = {
   repeatIntervalMs: number;
 };
 
-export type GamepadButtonBinding = {
-  button: number;
-  action: GameplayAction;
-  repeat: boolean;
-  label: string;
+export type ControllerInput = {
+  mapper: ProconMapper<InputAction>;
+  savedConfigState: SavedControllerConfigState;
 };
 
-export type GamepadAxisBinding = {
-  axis: number;
-  direction: -1 | 1;
-  action: GameplayAction;
-  label: string;
+export type ControllerDebugSnapshot = {
+  supported: boolean;
+  connectedGamepads: DetectedGamepad[];
+  selectedGamepad: DetectedGamepad | null;
+  inputs: PhysicalInputState;
+  actions: ActionState<InputAction>;
+  deadZone: number;
+  savedConfigState: SavedControllerConfigState;
 };
 
-export type MenuGamepadButtonBinding = {
-  button: number;
-  action: MenuAction;
-  repeat: boolean;
-  label: string;
+export const controllerStorageKey = 'game_tetris_like:procon:v1';
+export const defaultControllerDeadZone = 0.55;
+
+export const controllerActionMapping: ActionMapping<InputAction> = {
+  moveLeft: ['dpadLeft', 'leftStickLeft'],
+  moveRight: ['dpadRight', 'leftStickRight'],
+  softDrop: ['dpadDown', 'leftStickDown'],
+  hardDrop: ['dpadUp', 'buttonX', 'buttonY'],
+  rotateCW: 'buttonA',
+  rotateCCW: 'buttonB',
+  hold: ['buttonL', 'buttonR', 'buttonZL', 'buttonZR'],
+  pause: 'buttonPlus',
+  menuPrevious: ['dpadUp', 'dpadLeft', 'leftStickUp', 'leftStickLeft'],
+  menuNext: ['dpadDown', 'dpadRight', 'leftStickDown', 'leftStickRight'],
+  confirm: ['buttonA', 'buttonPlus'],
+  back: ['buttonB', 'buttonMinus'],
 };
 
-export type MenuGamepadAxisBinding = {
-  axis: number;
-  direction: -1 | 1;
-  action: MenuAction;
-  label: string;
-};
-
-export type GamepadButtonDebugState = {
-  index: number;
-  label: string;
-  pressed: boolean;
-  value: number;
-};
-
-export type GamepadDirectionDebugState = {
-  action: GameplayAction | MenuAction;
-  label: string;
-  pressed: boolean;
-  sources: InputSource[];
-};
-
-export type GamepadDebugSnapshot = {
-  connected: boolean;
-  id: string | null;
-  index: number | null;
-  axes: number[];
-  buttons: GamepadButtonDebugState[];
-  directions: GamepadDirectionDebugState[];
-  activeActionSources: Map<InputAction, InputSource[]>;
-};
+export const controllerPhysicalInputs: ProconPhysicalInput[] = [
+  'buttonA',
+  'buttonB',
+  'buttonX',
+  'buttonY',
+  'buttonL',
+  'buttonR',
+  'buttonZL',
+  'buttonZR',
+  'buttonMinus',
+  'buttonPlus',
+  'dpadUp',
+  'dpadDown',
+  'dpadLeft',
+  'dpadRight',
+  'leftStickUp',
+  'leftStickDown',
+  'leftStickLeft',
+  'leftStickRight',
+];
 
 export const createInputTimingState = (): InputTimingState => ({
   heldActions: new Set<InputAction>(),
@@ -102,10 +115,10 @@ export const keyboardMap = new Map<string, GameplayAction>([
   ['ArrowDown', 'softDrop'],
   ['KeyS', 'softDrop'],
   ['Space', 'hardDrop'],
-  ['ArrowUp', 'rotateClockwise'],
-  ['KeyW', 'rotateClockwise'],
-  ['KeyX', 'rotateClockwise'],
-  ['KeyZ', 'rotateCounterclockwise'],
+  ['ArrowUp', 'rotateCW'],
+  ['KeyW', 'rotateCW'],
+  ['KeyX', 'rotateCW'],
+  ['KeyZ', 'rotateCCW'],
   ['KeyC', 'hold'],
   ['ShiftLeft', 'hold'],
   ['ShiftRight', 'hold'],
@@ -127,43 +140,6 @@ export const keyboardMenuMap = new Map<string, MenuAction>([
   ['Escape', 'back'],
 ]);
 
-export const gamepadButtonMap: GamepadButtonBinding[] = [
-  { button: 14, action: 'moveLeft', repeat: true, label: 'D-Pad Left' },
-  { button: 15, action: 'moveRight', repeat: true, label: 'D-Pad Right' },
-  { button: 13, action: 'softDrop', repeat: true, label: 'D-Pad Down' },
-  { button: 0, action: 'rotateClockwise', repeat: false, label: 'A' },
-  { button: 1, action: 'rotateCounterclockwise', repeat: false, label: 'B' },
-  { button: 2, action: 'hardDrop', repeat: false, label: 'X' },
-  { button: 3, action: 'hardDrop', repeat: false, label: 'Y' },
-  { button: 4, action: 'hold', repeat: false, label: 'L' },
-  { button: 5, action: 'hold', repeat: false, label: 'R' },
-  { button: 9, action: 'pause', repeat: false, label: '+' },
-];
-
-export const gamepadAxisMap: GamepadAxisBinding[] = [
-  { axis: 0, direction: -1, action: 'moveLeft', label: 'Left Stick Left' },
-  { axis: 0, direction: 1, action: 'moveRight', label: 'Left Stick Right' },
-  { axis: 1, direction: 1, action: 'softDrop', label: 'Left Stick Down' },
-];
-
-export const menuGamepadButtonMap: MenuGamepadButtonBinding[] = [
-  { button: 12, action: 'menuPrevious', repeat: true, label: 'D-Pad Up' },
-  { button: 14, action: 'menuPrevious', repeat: true, label: 'D-Pad Left' },
-  { button: 13, action: 'menuNext', repeat: true, label: 'D-Pad Down' },
-  { button: 15, action: 'menuNext', repeat: true, label: 'D-Pad Right' },
-  { button: 0, action: 'confirm', repeat: false, label: 'A' },
-  { button: 9, action: 'confirm', repeat: false, label: '+' },
-  { button: 1, action: 'back', repeat: false, label: 'B' },
-  { button: 8, action: 'back', repeat: false, label: '-' },
-];
-
-export const menuGamepadAxisMap: MenuGamepadAxisBinding[] = [
-  { axis: 0, direction: -1, action: 'menuPrevious', label: 'Left Stick Left' },
-  { axis: 1, direction: -1, action: 'menuPrevious', label: 'Left Stick Up' },
-  { axis: 0, direction: 1, action: 'menuNext', label: 'Left Stick Right' },
-  { axis: 1, direction: 1, action: 'menuNext', label: 'Left Stick Down' },
-];
-
 export const repeatableActions = new Set<InputAction>([
   'moveLeft',
   'moveRight',
@@ -172,44 +148,101 @@ export const repeatableActions = new Set<InputAction>([
   'menuNext',
 ]);
 
-const trackedButtonLabels = new Map<number, string>([
-  [0, 'A'],
-  [1, 'B'],
-  [2, 'X'],
-  [3, 'Y'],
-  [4, 'L'],
-  [5, 'R'],
-  [8, '-'],
-  [9, '+'],
-  [12, 'D-Pad Up'],
-  [13, 'D-Pad Down'],
-  [14, 'D-Pad Left'],
-  [15, 'D-Pad Right'],
+export const gameplayActions = new Set<InputAction>([
+  'moveLeft',
+  'moveRight',
+  'softDrop',
+  'hardDrop',
+  'rotateCW',
+  'rotateCCW',
+  'hold',
+  'pause',
 ]);
 
-const directionLabels = new Map<InputAction, string>([
-  ['moveLeft', 'Left'],
-  ['moveRight', 'Right'],
-  ['softDrop', 'Down'],
-  ['menuPrevious', 'Previous'],
-  ['menuNext', 'Next'],
-  ['confirm', 'Confirm'],
-  ['back', 'Back'],
+export const menuActions = new Set<InputAction>([
+  'menuPrevious',
+  'menuNext',
+  'confirm',
+  'back',
 ]);
 
-export const createEmptyGamepadSnapshot = (): GamepadDebugSnapshot => ({
-  connected: false,
-  id: null,
-  index: null,
-  axes: [0, 0],
-  buttons: Array.from(trackedButtonLabels, ([index, label]) => ({
-    index,
-    label,
-    pressed: false,
-    value: 0,
-  })),
-  directions: [],
-  activeActionSources: new Map<InputAction, InputSource[]>(),
+export const oneShotControllerActions = new Set<InputAction>([
+  'hardDrop',
+  'rotateCW',
+  'rotateCCW',
+  'hold',
+  'pause',
+  'confirm',
+  'back',
+]);
+
+export const physicalInputLabels: Record<ProconPhysicalInput, string> = {
+  buttonA: 'A',
+  buttonB: 'B',
+  buttonX: 'X',
+  buttonY: 'Y',
+  buttonL: 'L',
+  buttonR: 'R',
+  buttonZL: 'ZL',
+  buttonZR: 'ZR',
+  buttonMinus: '-',
+  buttonPlus: '+',
+  buttonHome: 'Home',
+  buttonCapture: 'Capture',
+  buttonLeftStick: 'Left Stick Button',
+  buttonRightStick: 'Right Stick Button',
+  dpadUp: 'D-Pad Up',
+  dpadDown: 'D-Pad Down',
+  dpadLeft: 'D-Pad Left',
+  dpadRight: 'D-Pad Right',
+  leftStickUp: 'Left Stick Up',
+  leftStickDown: 'Left Stick Down',
+  leftStickLeft: 'Left Stick Left',
+  leftStickRight: 'Left Stick Right',
+  rightStickUp: 'Right Stick Up',
+  rightStickDown: 'Right Stick Down',
+  rightStickLeft: 'Right Stick Left',
+  rightStickRight: 'Right Stick Right',
+};
+
+export const createControllerInput = (): ControllerInput => {
+  const mapper = createProconMapper<InputAction>({
+    mapping: controllerActionMapping,
+    deadZone: defaultControllerDeadZone,
+    storageKey: controllerStorageKey,
+  });
+
+  const savedConfigState = mapper.load() ? 'loaded' : 'default';
+  return { mapper, savedConfigState };
+};
+
+export const createEmptyControllerDebugSnapshot = (
+  savedConfigState: SavedControllerConfigState = 'default',
+): ControllerDebugSnapshot => ({
+  supported: typeof navigator !== 'undefined' && typeof navigator.getGamepads === 'function',
+  connectedGamepads: [],
+  selectedGamepad: null,
+  inputs: Object.fromEntries(
+    controllerPhysicalInputs.map((input) => [input, false]),
+  ) as PhysicalInputState,
+  actions: Object.fromEntries(
+    (Object.keys(controllerActionMapping) as InputAction[]).map((action) => [action, false]),
+  ) as ActionState<InputAction>,
+  deadZone: defaultControllerDeadZone,
+  savedConfigState,
+});
+
+export const createControllerDebugSnapshot = (
+  controller: ControllerInput,
+  actions: ActionState<InputAction>,
+): ControllerDebugSnapshot => ({
+  supported: typeof navigator !== 'undefined' && typeof navigator.getGamepads === 'function',
+  connectedGamepads: controller.mapper.getConnectedGamepads(),
+  selectedGamepad: controller.mapper.getSelectedGamepad(),
+  inputs: controller.mapper.getInputState(),
+  actions,
+  deadZone: controller.mapper.getDeadZone(),
+  savedConfigState: controller.savedConfigState,
 });
 
 const addActionSource = (
@@ -222,8 +255,16 @@ const addActionSource = (
   actionSources.set(action, sources);
 };
 
-const isAxisActive = (value: number, direction: -1 | 1, threshold: number): boolean =>
-  direction < 0 ? value <= -threshold : value >= threshold;
+export const getActionMode = (action: InputAction): InputMode =>
+  gameplayActions.has(action) ? 'gameplay' : 'menu';
+
+const actionMatchesMode = (action: InputAction, mode: InputMode): boolean =>
+  getActionMode(action) === mode;
+
+export const getControllerActionInputs = (action: InputAction): ProconPhysicalInput[] => {
+  const inputs = controllerActionMapping[action];
+  return Array.isArray(inputs) ? inputs : [inputs];
+};
 
 export const collectKeyboardActionStates = (
   pressedCodes: Set<string>,
@@ -252,78 +293,27 @@ export const collectKeyboardActionStates = (
   }));
 };
 
-export const collectGamepadActionStates = (
-  gamepad: Pick<Gamepad, 'axes' | 'buttons' | 'id' | 'index'> | null,
+export const collectControllerActionStates = (
+  actions: ActionState<InputAction>,
   mode: InputMode,
-  axisThreshold: number,
-): { states: ActionInputState[]; snapshot: GamepadDebugSnapshot } => {
-  if (!gamepad) {
-    return { states: [], snapshot: createEmptyGamepadSnapshot() };
-  }
-
-  const actionSources = new Map<InputAction, InputSource[]>();
-  const buttonBindings = mode === 'gameplay' ? gamepadButtonMap : menuGamepadButtonMap;
-  const axisBindings = mode === 'gameplay' ? gamepadAxisMap : menuGamepadAxisMap;
-
-  buttonBindings.forEach((binding) => {
-    const button = gamepad.buttons[binding.button];
-    if (!button?.pressed) {
-      return;
-    }
-
-    addActionSource(actionSources, binding.action, {
-      type: 'gamepadButton',
-      id: String(binding.button),
-      label: binding.label,
-    });
-  });
-
-  axisBindings.forEach((binding) => {
-    const value = gamepad.axes[binding.axis] ?? 0;
-    if (!isAxisActive(value, binding.direction, axisThreshold)) {
-      return;
-    }
-
-    addActionSource(actionSources, binding.action, {
-      type: 'gamepadAxis',
-      id: `${binding.axis}:${binding.direction}`,
-      label: binding.label,
-    });
-  });
-
-  const buttons = Array.from(trackedButtonLabels, ([index, label]) => {
-    const button = gamepad.buttons[index];
-    return {
-      index,
-      label,
-      pressed: button?.pressed ?? false,
-      value: button?.value ?? 0,
-    };
-  });
-  const directions = Array.from(actionSources, ([action, sources]) => ({
-    action,
-    label: directionLabels.get(action) ?? action,
-    pressed: true,
-    sources,
-  }));
-
-  return {
-    states: Array.from(actionSources, ([action, sources]) => ({
+): ActionInputState[] =>
+  (Object.keys(controllerActionMapping) as InputAction[])
+    .filter((action) => actionMatchesMode(action, mode))
+    .filter((action) => actions[action] && !oneShotControllerActions.has(action))
+    .map((action) => ({
       action,
       pressed: true,
-      sources,
-    })),
-    snapshot: {
-      connected: true,
-      id: gamepad.id,
-      index: gamepad.index,
-      axes: Array.from(gamepad.axes).slice(0, 4),
-      buttons,
-      directions,
-      activeActionSources: actionSources,
-    },
-  };
-};
+      sources: getControllerActionInputs(action).map((input) => ({
+        type: 'controller',
+        id: input,
+        label: physicalInputLabels[input],
+      })),
+    }));
+
+export const filterControllerEdgeActions = (
+  actions: InputAction[],
+  mode: InputMode,
+): InputAction[] => actions.filter((action) => actionMatchesMode(action, mode));
 
 export const resolveTriggeredActions = (
   states: ActionInputState[],
@@ -368,14 +358,4 @@ export const resolveTriggeredActions = (
   return triggered;
 };
 
-export const shouldApplyGamepadAction = (
-  appliedActions: Set<InputAction>,
-  action: InputAction,
-): boolean => {
-  if (appliedActions.has(action)) {
-    return false;
-  }
-
-  appliedActions.add(action);
-  return true;
-};
+export const dedupeActions = (actions: InputAction[]): InputAction[] => Array.from(new Set(actions));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,21 @@
 import './styles/app.css';
 import {
-  collectGamepadActionStates,
+  collectControllerActionStates,
   collectKeyboardActionStates,
-  createEmptyGamepadSnapshot,
+  createControllerDebugSnapshot,
+  createControllerInput,
+  createEmptyControllerDebugSnapshot,
   createInputTimingState,
+  dedupeActions,
+  filterControllerEdgeActions,
+  getControllerActionInputs,
   keyboardMap,
   keyboardMenuMap,
+  physicalInputLabels,
+  controllerPhysicalInputs,
   resolveTriggeredActions,
 } from './game/input';
-import type { GamepadDebugSnapshot, GameplayAction, InputAction, InputMode } from './game/input';
+import type { ControllerDebugSnapshot, GameplayAction, InputAction, InputMode } from './game/input';
 import {
   calculateDropInterval,
   calculateLevel,
@@ -30,7 +37,6 @@ type PieceDefinition = {
   cells: Point[];
   color: string;
 };
-type GamepadConnectionState = 'waiting' | 'connected' | 'disconnected' | 'unsupported';
 
 const boardColumns = 10;
 const boardRows = 20;
@@ -38,7 +44,6 @@ const baseDropIntervalMs = 650;
 const minDropIntervalMs = 120;
 const inputRepeatDelayMs = 260;
 const inputRepeatIntervalMs = 120;
-const gamepadAxisThreshold = 0.55;
 const palette = {
   active: '#79d3c8',
   fixed: '#f2c14e',
@@ -98,10 +103,12 @@ let lines = 0;
 let level = 1;
 const pressedKeyboardCodes = new Set<string>();
 const inputTimingState = createInputTimingState();
-let activeGamepadIndex: number | null = null;
-let activeGamepadName: string | null = null;
+const controllerInput = createControllerInput();
+const controllerEdgeActions: InputAction[] = [];
 let selectedTitleMenuIndex = 0;
-let latestGamepadSnapshot: GamepadDebugSnapshot = createEmptyGamepadSnapshot();
+let latestControllerSnapshot: ControllerDebugSnapshot = createEmptyControllerDebugSnapshot(
+  controllerInput.savedConfigState,
+);
 let suppressInputUntilNeutral = false;
 let lastControlsRenderTime = 0;
 const highScoreStorageKey = 'falling-blocks:high-score';
@@ -126,8 +133,6 @@ const saveHighScore = (value: number): void => {
 };
 
 let highScore = loadHighScore();
-let gamepadConnectionState: GamepadConnectionState =
-  'getGamepads' in navigator ? 'waiting' : 'unsupported';
 
 const formatScore = (value: number): string => value.toString().padStart(6, '0');
 
@@ -202,14 +207,14 @@ const returnToTitle = (): void => {
 };
 
 const getGamepadStatusText = (): string => {
-  if (gamepadConnectionState === 'connected' && activeGamepadName) {
-    return `Connected: ${activeGamepadName}`;
-  }
-  if (gamepadConnectionState === 'disconnected') {
-    return 'Disconnected';
-  }
-  if (gamepadConnectionState === 'unsupported') {
+  if (!latestControllerSnapshot.supported) {
     return 'Gamepad API unavailable';
+  }
+  if (latestControllerSnapshot.selectedGamepad) {
+    return `Connected: ${latestControllerSnapshot.selectedGamepad.id}`;
+  }
+  if (latestControllerSnapshot.connectedGamepads.length > 0) {
+    return 'Connected';
   }
   return 'Waiting for controller';
 };
@@ -435,9 +440,9 @@ const applyGameplayAction = (action: GameplayAction): void => {
     }
   } else if (action === 'hardDrop') {
     hardDropCurrentPiece();
-  } else if (action === 'rotateClockwise') {
+  } else if (action === 'rotateCW') {
     rotateCurrentPiece(true);
-  } else if (action === 'rotateCounterclockwise') {
+  } else if (action === 'rotateCCW') {
     rotateCurrentPiece(false);
   } else if (action === 'hold') {
     holdCurrentPiece();
@@ -448,28 +453,6 @@ const applyGameplayAction = (action: GameplayAction): void => {
       resumeGame();
     }
   }
-};
-
-const getActiveGamepad = (): Gamepad | null => {
-  const gamepads = navigator.getGamepads?.();
-  if (!gamepads) {
-    return null;
-  }
-
-  if (activeGamepadIndex !== null) {
-    return gamepads[activeGamepadIndex] ?? null;
-  }
-
-  const gamepad = gamepads.find((candidate) => candidate !== null);
-  if (!gamepad) {
-    return null;
-  }
-
-  activeGamepadIndex = gamepad.index;
-  activeGamepadName = gamepad.id;
-  gamepadConnectionState = 'connected';
-  render();
-  return gamepad;
 };
 
 const getInputMode = (): InputMode =>
@@ -516,19 +499,15 @@ const applyTriggeredAction = (action: InputAction): void => {
 };
 
 const pollInputs = (timestamp: number): void => {
-  const gamepad = getActiveGamepad();
   const mode = getInputMode();
   const keyboardStates = collectKeyboardActionStates(pressedKeyboardCodes, mode);
-  const { states: gamepadStates, snapshot } = collectGamepadActionStates(
-    gamepad,
-    mode,
-    gamepadAxisThreshold,
-  );
-
-  latestGamepadSnapshot = snapshot;
-  const inputStates = [...keyboardStates, ...gamepadStates];
+  const controllerActions = controllerInput.mapper.getPressedActions();
+  latestControllerSnapshot = createControllerDebugSnapshot(controllerInput, controllerActions);
+  const controllerStates = collectControllerActionStates(controllerActions, mode);
+  const inputStates = [...keyboardStates, ...controllerStates];
+  const hasActiveControllerAction = Object.values(controllerActions).some(Boolean);
   if (suppressInputUntilNeutral) {
-    if (!inputStates.some((state) => state.pressed)) {
+    if (!inputStates.some((state) => state.pressed) && !hasActiveControllerAction) {
       suppressInputUntilNeutral = false;
     }
     inputTimingState.heldActions.clear();
@@ -537,15 +516,12 @@ const pollInputs = (timestamp: number): void => {
     return;
   }
 
-  const actions = resolveTriggeredActions(
-    inputStates,
-    inputTimingState,
-    timestamp,
-    {
-      repeatDelayMs: inputRepeatDelayMs,
-      repeatIntervalMs: inputRepeatIntervalMs,
-    },
-  );
+  const heldActions = resolveTriggeredActions(inputStates, inputTimingState, timestamp, {
+    repeatDelayMs: inputRepeatDelayMs,
+    repeatIntervalMs: inputRepeatIntervalMs,
+  });
+  const edgeActions = filterControllerEdgeActions(controllerEdgeActions.splice(0), mode);
+  const actions = dedupeActions([...heldActions, ...edgeActions]);
   actions.forEach(applyTriggeredAction);
 };
 
@@ -683,8 +659,6 @@ const renderGameOverOverlay = (): string => `
   </section>
 `;
 
-const formatAxisValue = (value: number | undefined): string => (value ?? 0).toFixed(2);
-
 const renderSourceList = (sources: { label: string; type: string }[]): string =>
   sources.length === 0
     ? '<span class="muted">Idle</span>'
@@ -693,45 +667,69 @@ const renderSourceList = (sources: { label: string; type: string }[]): string =>
         .join('');
 
 const renderGamepadDiagnostics = (): string => {
-  const snapshot = latestGamepadSnapshot;
-  const axisX = snapshot.axes[0] ?? 0;
-  const axisY = snapshot.axes[1] ?? 0;
-  const stickX = Math.max(0, Math.min(100, 50 + axisX * 42));
-  const stickY = Math.max(0, Math.min(100, 50 + axisY * 42));
-  const directionActions: InputAction[] = [
-    currentScreen === 'controls' ? 'menuPrevious' : 'moveLeft',
-    currentScreen === 'controls' ? 'menuNext' : 'moveRight',
-    'confirm',
-    'back',
-  ];
-  const activeButtons = snapshot.buttons.filter((button) => button.pressed);
+  const snapshot = latestControllerSnapshot;
+  const activeInputs = controllerPhysicalInputs.filter((input) => snapshot.inputs[input]);
+  const actionsToShow: InputAction[] =
+    currentScreen === 'controls'
+      ? ['menuPrevious', 'menuNext', 'confirm', 'back']
+      : ['moveLeft', 'moveRight', 'softDrop', 'hardDrop', 'rotateCW', 'rotateCCW', 'hold', 'pause'];
+  const connectedGamepads = snapshot.connectedGamepads;
 
   return `
     <section class="controller-debug" aria-label="Controller input monitor">
       <div class="debug-status">
         <div>
           <dt>Status</dt>
-          <dd>${snapshot.connected ? 'Connected' : getGamepadStatusText()}</dd>
+          <dd>${getGamepadStatusText()}</dd>
         </div>
         <div>
-          <dt>Controller</dt>
-          <dd>${snapshot.id ? escapeHtml(snapshot.id) : 'None'}</dd>
+          <dt>Selected Controller</dt>
+          <dd>${snapshot.selectedGamepad ? escapeHtml(snapshot.selectedGamepad.id) : 'None'}</dd>
         </div>
         <div>
-          <dt>Index</dt>
-          <dd>${snapshot.index ?? '-'}</dd>
+          <dt>Confidence</dt>
+          <dd>${snapshot.selectedGamepad ? snapshot.selectedGamepad.confidence : '-'}</dd>
+        </div>
+        <div>
+          <dt>Dead Zone</dt>
+          <dd>${snapshot.deadZone.toFixed(2)}</dd>
+        </div>
+        <div>
+          <dt>Saved Settings</dt>
+          <dd>${snapshot.savedConfigState === 'loaded' ? 'Loaded' : 'Default'}</dd>
         </div>
       </div>
 
       <div class="debug-grid">
         <section class="debug-block">
-          <h3>D-Pad / Directions</h3>
+          <h3>Connected Gamepads</h3>
+          <div class="button-monitor">
+            ${
+              connectedGamepads.length > 0
+                ? connectedGamepads
+                    .map(
+                      (gamepad) => `<span class="${gamepad.index === snapshot.selectedGamepad?.index ? 'is-active' : ''}">
+                        ${escapeHtml(gamepad.id)}
+                      </span>`,
+                    )
+                    .join('')
+                : '<span class="muted">None</span>'
+            }
+          </div>
+        </section>
+
+        <section class="debug-block">
+          <h3>Mapped Actions</h3>
           <div class="direction-pad">
-            ${directionActions
+            ${actionsToShow
               .map((action) => {
-                const sources = snapshot.activeActionSources.get(action) ?? [];
+                const sources = getControllerActionInputs(action).map((input) => ({
+                  type: 'controller',
+                  label: physicalInputLabels[input],
+                }));
+                const pressed = snapshot.actions[action];
                 const sourceClass = sources.length > 1 ? ' multi-source' : '';
-                return `<div class="direction-cell${sources.length > 0 ? ' is-active' : ''}${sourceClass}">
+                return `<div class="direction-cell${pressed ? ' is-active' : ''}${sourceClass}">
                   <span>${action}</span>
                   <small>${renderSourceList(sources)}</small>
                 </div>`;
@@ -741,30 +739,20 @@ const renderGamepadDiagnostics = (): string => {
         </section>
 
         <section class="debug-block">
-          <h3>Left Stick</h3>
-          <div class="stick-preview" aria-label="Left stick position">
-            <span style="left: ${stickX}%; top: ${stickY}%"></span>
-          </div>
-          <dl class="axis-readout">
-            <div><dt>Axis 0</dt><dd>${formatAxisValue(axisX)}</dd></div>
-            <div><dt>Axis 1</dt><dd>${formatAxisValue(axisY)}</dd></div>
-          </dl>
-        </section>
-
-        <section class="debug-block">
-          <h3>Buttons</h3>
+          <h3>Input State</h3>
           <div class="button-monitor">
-            ${snapshot.buttons
-              .map(
-                (button) => `<span class="${button.pressed ? 'is-active' : ''}">
-                  ${button.index}: ${escapeHtml(button.label)}
-                </span>`,
-              )
+            ${controllerPhysicalInputs
+              .map((input) => {
+                const pressed = snapshot.inputs[input];
+                return `<span class="${pressed ? 'is-active' : ''}">
+                  ${escapeHtml(physicalInputLabels[input])}
+                </span>`;
+              })
               .join('')}
           </div>
           <p class="connection-state">Pressed: ${
-            activeButtons.length > 0
-              ? activeButtons.map((button) => escapeHtml(button.label)).join(', ')
+            activeInputs.length > 0
+              ? activeInputs.map((input) => escapeHtml(physicalInputLabels[input])).join(', ')
               : 'None'
           }</p>
         </section>
@@ -797,13 +785,13 @@ const renderControls = (): string => `
         <h2>Controller</h2>
         <dl>
           <div><dt>D-Pad / Left Stick</dt><dd>Move / Soft Drop</dd></div>
-          <div><dt>A / B</dt><dd>Rotate</dd></div>
-          <div><dt>X / Y</dt><dd>Hard Drop</dd></div>
-          <div><dt>L / R</dt><dd>Hold</dd></div>
+          <div><dt>A / B</dt><dd>Rotate CW / CCW</dd></div>
+          <div><dt>D-Pad Up / X / Y</dt><dd>Hard Drop</dd></div>
+          <div><dt>L / R / ZL / ZR</dt><dd>Hold</dd></div>
           <div><dt>+</dt><dd>Pause</dd></div>
         </dl>
         <p class="connection-state">Gamepad Status: ${getGamepadStatusText()}</p>
-        <p class="connection-state">Button numbers can vary by OS and browser.</p>
+        <p class="connection-state">Controller input is mapped through procon-gamepad-mapper.</p>
         ${renderGamepadDiagnostics()}
       </article>
     </section>
@@ -965,22 +953,25 @@ root.addEventListener('click', (event) => {
   }
 });
 
-window.addEventListener('gamepadconnected', (event) => {
-  activeGamepadIndex = event.gamepad.index;
-  activeGamepadName = event.gamepad.id;
-  gamepadConnectionState = 'connected';
+controllerInput.mapper.on('actiondown', (event) => {
+  controllerEdgeActions.push(event.action);
+});
+
+window.addEventListener('gamepadconnected', () => {
+  latestControllerSnapshot = createControllerDebugSnapshot(
+    controllerInput,
+    controllerInput.mapper.getPressedActions(),
+  );
   render();
 });
 
-window.addEventListener('gamepaddisconnected', (event) => {
-  if (activeGamepadIndex === event.gamepad.index) {
-    activeGamepadIndex = null;
-    activeGamepadName = null;
-    gamepadConnectionState = 'disconnected';
-    latestGamepadSnapshot = createEmptyGamepadSnapshot();
-    resetInputTiming();
-    render();
-  }
+window.addEventListener('gamepaddisconnected', () => {
+  latestControllerSnapshot = createControllerDebugSnapshot(
+    controllerInput,
+    controllerInput.mapper.getPressedActions(),
+  );
+  resetInputTiming();
+  render();
 });
 
 window.addEventListener('keydown', (event) => {


### PR DESCRIPTION
## Summary
- Integrate `procon-gamepad-mapper` through a GitHub dependency
- Replace direct gamepad button/axis mappings with named controller actions
- Update controller diagnostics, docs, Docker, and Pages dependency setup

## Validation
- `npm run test`
- `npm run build`
- `BASE_PATH=/game_tetris_like/ npm run build`
- `docker compose build`
- `make install`
- `make test`
- `make build`